### PR TITLE
parse cues with multiple newlines, removed dbg!

### DIFF
--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -49,7 +49,6 @@ impl FromStr for Time {
             2 => {
                 t.h = 0;
                 t.m = splits.first().unwrap_or(&"0").to_string().parse::<u32>()?;
-                dbg!(splits.clone());
                 let sms = splits
                     .get(1)
                     .unwrap_or(&"0.0")

--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -269,15 +269,17 @@ impl FromStr for VTTFile {
             b = path_or_content;
         }
         let (split, ssplit) = if b.split("\r\n\r\n").count() < 2 {
-            ("\n\n", "\n")
+            (r"\n{2,}", "\n")
         } else {
-            ("\r\n\r\n", "\r\n")
+            (r"((\r\n){2,})", "\r\n")
         };
-        let line_blocks = b.split(split).collect::<Vec<&str>>();
+        let blank_line_sep = Regex::new(split).expect("Invalid blank line regex");
+        let line_blocks = blank_line_sep.split(&b).collect::<Vec<&str>>();
         // Unwrapping here is safe because the above split will always have `Some(&[""])`.
         if !line_blocks.first().unwrap().contains("WEBVTT") {
             panic!("Not a  WEBVTT file");
         }
+
         let mut line_found = false;
         let mut styles_found = 0;
         for i in line_blocks {


### PR DESCRIPTION
Hello adracea,
I've been using your library for a personal project, thank you for the effort you've put into this!
I've noticed that in some old vtt files the cues where seperated by multiple newlines instead of just one. Also, the times where expressed in "00:00.000" (only two segments seperated by ":" instead of 3).
Looking at the [specs](https://www.w3.org/TR/webvtt1/#file-structure) (in the box, at point 7) it actually allows you to have multiple newlines between cues, so it wasn't a deprecated feature.
Running this library on such a file, would result in 2 problematic behaviours:

1. it crashed because of the multiple newlines
2. it printed all the splitted times

In this pr, I used a regex to match for multiple newlines and removed the `dbg!` that was printing the splitted times.
I've run the the tests and all passed.

Hope this can be useful, have a nice day