### PR TITLE
Enhance types and functions

### DIFF
--- a/examples/change_style_colors.rs
+++ b/examples/change_style_colors.rs
@@ -4,7 +4,7 @@ use rsubs_lib::util::color;
 use rsubs_lib::util::color::ColorType;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut ssa = rsubs_lib::ssa::parse("tests/fixtures/test.ass".to_string())
+    let mut ssa = rsubs_lib::ssa::parse_from_file("tests/fixtures/test.ass".to_string())
         .expect("Encountered Error parsing file");
     for style in ssa.styles.iter_mut() {
         if style.name == "Default" {

--- a/examples/convert_around.rs
+++ b/examples/convert_around.rs
@@ -9,10 +9,10 @@ fn main() {
         // converts file to WEBVTT
         .to_file("./tests/fixtures/ex_test_1.vtt") // Writes the converted subtitle to a file
         .unwrap();
-    ssa::SSAFile::from(vtt::parse("./tests/fixtures/test.vtt".to_string()).unwrap()) // converts file to SSA/ASS
+    ssa::SSAFile::from(vtt::parse_from_file("./tests/fixtures/test.vtt".to_string()).unwrap()) // converts file to SSA/ASS
         .to_file("./tests/fixtures/ex_test_1.ass")
         .unwrap();
-    srt::SRTFile::from(ssa::parse("./tests/fixtures/test.ass".to_string()).unwrap())
+    srt::SRTFile::from(ssa::parse_from_file("./tests/fixtures/test.ass".to_string()).unwrap())
         // converts file to SRT
         .to_file("./tests/fixtures/ex_test_1.srt")
         .unwrap();

--- a/examples/shift_srt_by_1s.rs
+++ b/examples/shift_srt_by_1s.rs
@@ -6,8 +6,8 @@ use rsubs_lib::{ssa::SSAFile, Subtitle};
 /// Afterwards we print the result to stdout.
 
 fn main() {
-    let mut srt =
-        rsubs_lib::srt::parse("tests/fixtures/test.srt".to_string()).expect("failed parsing");
+    let mut srt = rsubs_lib::srt::parse_from_file("tests/fixtures/test.srt".to_string())
+        .expect("failed parsing");
     for line in srt.lines.iter_mut() {
         line.line_end += 20;
         line.line_start += 50;

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -8,34 +8,31 @@
 
 use serde::Deserialize;
 use serde::Serialize;
-use std::ops::Add;
+use std::fmt;
 use std::ops::AddAssign;
 use std::ops::Sub;
+use std::ops::{Add, SubAssign};
 use std::result::Result;
 use std::str::FromStr;
-use std::{fmt, ops::Div};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Time {
-    pub h: u32,
-    pub m: u32,
-    pub s: u32,
-    pub ms: u32,
-    pub frames: u32,
-    pub fps: f32,
+    h: u32,
+    m: u32,
+    s: u32,
+    ms: u32,
+    fps: f32,
 }
 impl Eq for Time {}
 impl Default for Time {
     fn default() -> Self {
-        let mut t = Time {
+        let t = Time {
             h: 0,
             m: 0,
             s: 0,
             ms: 0,
-            frames: 0,
             fps: 0.0,
         };
-        t.derive_frames();
         t
     }
 }
@@ -84,91 +81,45 @@ impl FromStr for Time {
         Ok(t)
     }
 }
-pub fn frames_to_ms(frames: u32, fps: f32) -> u32 {
-    if frames == 0 || fps == 0.0 {
-        0
-    } else {
-        (((frames as f32) * (10000.0)) / fps).round() as u32 / 10
-    }
-}
-pub fn ms_to_frames(ms: u32, fps: f32) -> u32 {
-    if fps == 0.0 {
-        0
-    } else {
-        ((ms as f32) * fps / 1000.0).round() as u32
-    }
-}
-pub fn ms_to_timestring(ms: u32) -> String {
-    let hms = ms.div(3600000);
-    let mms = (ms - hms * 3600000).div(60000);
-    let sms = (ms - mms * 60000 - hms * 3600000).div(1000);
-    let msms = &format!(
-        "0.{:0>3}",
-        ((ms - mms * 60000 - hms * 3600000 - sms * 1000) as f32)
-    );
-    let mmmms = msms
-        .split('.')
-        .collect::<Vec<&str>>()
-        .get(1)
-        .or(Some(&"0"))
-        .expect("Should be good")
-        .to_string();
-    format!("{hms:0>2}")
-        + ":"
-        + &format!("{mms:0>2}")
-        + ":"
-        + &format!("{sms:0>2}")
-        + "."
-        + &format!("{mmmms:0>3}")
-}
 
 impl std::error::Error for Time {}
 impl Time {
+    pub fn from_ms(ms: u32) -> Self {
+        let mut this = Self::default();
+        this.set_ms(ms);
+        this
+    }
+
     pub fn total_ms(&self) -> u32 {
         self.h * 3600000 + self.m * 60000 + self.s * 1000 + self.ms
     }
-    pub fn update_from_fps_frames(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let t = Time::from_str(&ms_to_timestring(frames_to_ms(self.frames, self.fps)))?;
-        self.h = t.h;
-        self.m = t.m;
-        self.s = t.s;
-        self.ms = t.ms;
-        Ok(())
-    }
-    pub fn derive_frames(&mut self) {
-        self.frames = ms_to_frames(self.total_ms(), self.fps);
-    }
-    pub fn set_fps(&mut self, fps: f32) {
-        self.fps = fps;
-        self.derive_frames();
-    }
-    pub fn update_from_ms(&mut self, ms: u32) -> Result<(), Box<dyn std::error::Error>> {
-        let t = Time::from_str(&ms_to_timestring(ms))?;
-        self.h = t.h;
-        self.m = t.m;
-        self.s = t.s;
-        self.ms = t.ms;
-        self.derive_frames();
-        Ok(())
-    }
-
-    // Adds <u32>ms to `self` and updates.
-    pub fn add_ms(&mut self, ms: u32) -> Result<(), Box<dyn std::error::Error>> {
-        self.update_from_ms(self.total_ms() + ms)?;
-        Ok(())
-    }
-    // Subtracts <u32>ms from `self` and updates. Panics if total ms < 0
-    pub fn sub_ms(&mut self, ms: u32) -> Result<(), &mut Time> {
-        if ms > self.total_ms() {
-            self.update_from_ms(self.total_ms() - self.total_ms())
-                .unwrap();
-            Err(self)
+    pub fn frames(&self) -> u32 {
+        if self.fps == 0.0 {
+            0
         } else {
-            self.update_from_ms(self.total_ms() - ms).unwrap();
-            Ok(())
+            ((self.total_ms() as f32) * self.fps / 1000.0).round() as u32
         }
     }
-    pub fn to_ass_string(self) -> String {
+    pub fn fps(&self) -> f32 {
+        self.fps
+    }
+
+    pub fn set_fps(&mut self, fps: f32) {
+        self.fps = fps;
+    }
+    pub fn set_ms(&mut self, ms: u32) {
+        const HOUR_DIVIDER: u32 = 1000 * 60 * 60;
+        const MINUTE_DIVIDER: u32 = 1000 * 60;
+        const SECOND_DIVIDER: u32 = 1000;
+
+        self.h = ms / HOUR_DIVIDER;
+        self.m = (ms - (self.h * HOUR_DIVIDER)) / MINUTE_DIVIDER;
+        self.s = (ms - (self.h * HOUR_DIVIDER) - (self.m * MINUTE_DIVIDER)) / SECOND_DIVIDER;
+        self.ms =
+            ms - (self.h * HOUR_DIVIDER) - (self.m * MINUTE_DIVIDER) - (self.s * SECOND_DIVIDER);
+    }
+
+    pub fn to_ass_string(&self) -> String {
         format!(
             "{:0>1}:{:0>2}:{:0>2}.{:0>2}",
             self.h,
@@ -177,83 +128,72 @@ impl Time {
             self.ms / 10
         )
     }
-    pub fn to_srt_string(self) -> String {
+    pub fn to_srt_string(&self) -> String {
         format!(
             "{:0>2}:{:0>2}:{:0>2},{:0>3}",
             self.h, self.m, self.s, self.ms
         )
     }
-}
-// Add <u32>ms to a `Time` struct
-impl Add<u32> for Time {
-    type Output = Time;
-    fn add(mut self, other: u32) -> Time {
-        self.add_ms(other).unwrap();
-        self
-    }
-}
-impl AddAssign<u32> for Time {
-    fn add_assign(&mut self, other: u32) {
-        self.add_ms(other).unwrap();
-    }
-}
-impl AddAssign<i32> for Time {
-    fn add_assign(&mut self, other: i32) {
-        self.add_ms(other.try_into().unwrap()).unwrap();
-    }
-}
-// Subtracts <u32>ms to a `Time` struct
-impl Sub<u32> for Time {
-    type Output = Self;
-    fn sub(mut self, other: u32) -> Self {
-        self.sub_ms(other).unwrap_or_default();
-        self
-    }
-} // Subtracts <i32>ms to a `Time` struct
-impl Sub<i32> for Time {
-    type Output = Self;
-    fn sub(mut self, other: i32) -> Self {
-        self.sub_ms(other.try_into().unwrap()).unwrap_or_default();
-        self
-    }
-}
-impl Sub<i32> for &mut Time {
-    type Output = Self;
-    fn sub(self, other: i32) -> Self {
-        self.sub_ms(other.try_into().unwrap()).unwrap_or_default();
-        self
-    }
-}
-impl Sub<u32> for &mut Time {
-    type Output = Self;
-    fn sub(self, other: u32) -> Self {
-        self.sub_ms(other).unwrap_or_default();
-        self
-    }
-}
-// Add <i32>ms to a `Time` struct
-impl Add<i32> for Time {
-    type Output = Self;
-    fn add(mut self, other: i32) -> Self {
-        self.add_ms(other.try_into().unwrap()).unwrap();
-        self
-    }
-}
-// Add <i32>ms to a `Time` struct
-impl Add<i32> for &mut Time {
-    type Output = Self;
-    fn add(self, other: i32) -> Self {
-        self.add_ms(other as u32).unwrap();
-        self
-    }
-}
-// Displays the time as `hh:mm:ss.mss`
-impl fmt::Display for Time {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
+    pub fn to_vtt_string(&self) -> String {
+        format!(
             "{:0>2}:{:0>2}:{:0>2}.{:0>3}",
             self.h, self.m, self.s, self.ms
         )
+    }
+}
+
+macro_rules! impl_ops {
+    ($($type:ty)*) => {
+        $(
+            impl Add<$type> for Time {
+                type Output = Time;
+                fn add(mut self, other: $type) -> Self::Output {
+                    self.set_ms(self.total_ms() + other as u32);
+                    self
+                }
+            }
+            impl Add<$type> for &mut Time {
+                type Output = Self;
+                fn add(self, other: $type) -> Self::Output {
+                    self.set_ms(self.total_ms() + other as u32);
+                    self
+                }
+            }
+            impl AddAssign<$type> for Time {
+                fn add_assign(&mut self, other: $type) {
+                    self.set_ms(self.total_ms() + other as u32)
+                }
+            }
+            impl Sub<$type> for Time {
+                type Output = Time;
+                fn sub(mut self, other: $type) -> Self::Output {
+                    self.set_ms(self.total_ms() - other as u32);
+                    self
+                }
+            }
+            impl Sub<$type> for &mut Time {
+                type Output = Self;
+                fn sub(self, other: $type) -> Self::Output {
+                    self.set_ms(self.total_ms() - other as u32);
+                    self
+                }
+            }
+            impl SubAssign<$type> for Time {
+                fn sub_assign(&mut self, other: $type) {
+                    self.set_ms(self.total_ms() - other as u32)
+                }
+            }
+        )*
+    };
+}
+
+impl_ops! {
+    i8 i16 i32 i64 i128 u8 u16 u32 u64 u128
+}
+
+// Displays the time as `hh:mm:ss.mss`
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_vtt_string())
     }
 }

--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -13,8 +13,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::str::FromStr;
 
 /// The VTTStyle contains information that generally composes the `::cue` header
@@ -105,7 +107,7 @@ impl Default for VTTFile {
 
 impl VTTFile {
     /// Takes the path of the file in the form of a [String] to be written to as input.
-    pub fn to_file(self, path: &str) -> std::io::Result<()> {
+    pub fn to_file<P: AsRef<Path>>(self, path: P) -> std::io::Result<()> {
         let mut w = File::options()
             .write(true)
             .create(true)
@@ -424,20 +426,40 @@ impl FromStr for VTTFile {
                     });
                     for (px, py) in poss {
                         if px == "position" {
-                            let pos_split = py.replace('%', "").split(',').map(|s| s.to_owned()).collect::<Vec<String>>();
-                            spos.pos = pos_split.first().unwrap_or(&"".to_string()).to_string().parse::<i32>().expect("number");
+                            let pos_split = py
+                                .replace('%', "")
+                                .split(',')
+                                .map(|s| s.to_owned())
+                                .collect::<Vec<String>>();
+                            spos.pos = pos_split
+                                .first()
+                                .unwrap_or(&"".to_string())
+                                .to_string()
+                                .parse::<i32>()
+                                .expect("number");
                             if pos_split.len() > 1 {
-                                spos.pos_align = Some(pos_split.get(1).unwrap_or(&"".to_string()).to_string());
+                                spos.pos_align =
+                                    Some(pos_split.get(1).unwrap_or(&"".to_string()).to_string());
                             }
                         } else if px == "align" {
                             spos.align = py;
                         } else if px == "size" {
                             spos.size = py.replace('%', "").parse::<i32>().expect("number");
                         } else if px == "line" {
-                            let line_split = py.replace('%', "").split(',').map(|s| s.to_owned()).collect::<Vec<String>>();
-                            spos.line = line_split.first().unwrap_or(&"".to_string()).to_string().parse::<i32>().expect("number");
+                            let line_split = py
+                                .replace('%', "")
+                                .split(',')
+                                .map(|s| s.to_owned())
+                                .collect::<Vec<String>>();
+                            spos.line = line_split
+                                .first()
+                                .unwrap_or(&"".to_string())
+                                .to_string()
+                                .parse::<i32>()
+                                .expect("number");
                             if line_split.len() > 1 {
-                                spos.line_align = Some(line_split.get(1).unwrap_or(&"".to_string()).to_string());
+                                spos.line_align =
+                                    Some(line_split.get(1).unwrap_or(&"".to_string()).to_string());
                             }
                         }
                     }
@@ -459,26 +481,15 @@ impl FromStr for VTTFile {
     }
 }
 
-/// Parses the given [String] into a [VTTFile]
-///
-/// The string may represent either the path to a file or the file content itself.
-pub fn parse(path_or_content: String) -> Result<VTTFile, std::io::Error> {
-    let mut b: String = "".to_string();
+/// Parses the given [String] into a [VTTFile].
+pub fn parse(content: String) -> VTTFile {
     let mut sub: VTTFile = VTTFile::default();
-    if !path_or_content.contains('\n') {
-        if std::fs::read(&path_or_content).is_ok() {
-            let mut f = File::open(path_or_content)?;
-            f.read_to_string(&mut b)?;
-        }
-    } else {
-        b = path_or_content;
-    }
-    let (split, ssplit) = if b.split("\r\n\r\n").count() < 2 {
+    let (split, ssplit) = if content.split("\r\n\r\n").count() < 2 {
         ("\n\n", "\n")
     } else {
         ("\r\n\r\n", "\r\n")
     };
-    let line_blocks = b.split(split).collect::<Vec<&str>>();
+    let line_blocks = content.split(split).collect::<Vec<&str>>();
     // Unwrapping here is safe because the above split will always have `Some(&[""])`.
     if !line_blocks.first().unwrap().contains("WEBVTT") {
         panic!("Not a  WEBVTT file");
@@ -627,20 +638,40 @@ pub fn parse(path_or_content: String) -> Result<VTTFile, std::io::Error> {
                 });
                 for (px, py) in poss {
                     if px == "position" {
-                        let pos_split = py.replace('%', "").split(',').map(|s| s.to_owned()).collect::<Vec<String>>();
-                        spos.pos = pos_split.first().unwrap_or(&"".to_string()).to_string().parse::<i32>().expect("number");
+                        let pos_split = py
+                            .replace('%', "")
+                            .split(',')
+                            .map(|s| s.to_owned())
+                            .collect::<Vec<String>>();
+                        spos.pos = pos_split
+                            .first()
+                            .unwrap_or(&"".to_string())
+                            .to_string()
+                            .parse::<i32>()
+                            .expect("number");
                         if pos_split.len() > 1 {
-                            spos.pos_align = Some(pos_split.get(1).unwrap_or(&"".to_string()).to_string());
+                            spos.pos_align =
+                                Some(pos_split.get(1).unwrap_or(&"".to_string()).to_string());
                         }
                     } else if px == "align" {
                         spos.align = py;
                     } else if px == "size" {
                         spos.size = py.replace('%', "").parse::<i32>().expect("number");
                     } else if px == "line" {
-                        let line_split = py.replace('%', "").split(',').map(|s| s.to_owned()).collect::<Vec<String>>();
-                        spos.line = line_split.first().unwrap_or(&"".to_string()).to_string().parse::<i32>().expect("number");
+                        let line_split = py
+                            .replace('%', "")
+                            .split(',')
+                            .map(|s| s.to_owned())
+                            .collect::<Vec<String>>();
+                        spos.line = line_split
+                            .first()
+                            .unwrap_or(&"".to_string())
+                            .to_string()
+                            .parse::<i32>()
+                            .expect("number");
                         if line_split.len() > 1 {
-                            spos.line_align = Some(line_split.get(1).unwrap_or(&"".to_string()).to_string());
+                            spos.line_align =
+                                Some(line_split.get(1).unwrap_or(&"".to_string()).to_string());
                         }
                     }
                 }
@@ -658,5 +689,10 @@ pub fn parse(path_or_content: String) -> Result<VTTFile, std::io::Error> {
             }
         }
     }
-    Ok(sub)
+    sub
+}
+
+/// Parses the given [Path] into a [VTTFile].
+pub fn parse_from_file<P: AsRef<Path>>(file: P) -> Result<VTTFile, std::io::Error> {
+    Ok(parse(fs::read_to_string(file)?))
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -19,7 +19,7 @@ mod tests {
     #[test]
     fn test_ssa_from_file_to_srt_file() {
         use rsubs_lib::ssa;
-        let ssafile = ssa::parse("./tests/fixtures/test.ass".to_string()).unwrap();
+        let ssafile = ssa::parse_from_file("./tests/fixtures/test.ass".to_string()).unwrap();
         ssafile
             .to_srt()
             .to_file("./tests/fixtures/res6.srt")
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn test_ssa_from_file_to_vtt_file() {
         use rsubs_lib::ssa;
-        let ssafile = ssa::parse("./tests/fixtures/test.ass".to_string()).unwrap();
+        let ssafile = ssa::parse_from_file("./tests/fixtures/test.ass".to_string()).unwrap();
         ssafile
             .to_vtt()
             .to_file("./tests/fixtures/res5.vtt")
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn test_ssa_from_file_to_ass_file() {
         use rsubs_lib::ssa;
-        let ssafile = ssa::parse("./tests/fixtures/test.ass".to_string()).unwrap();
+        let ssafile = ssa::parse_from_file("./tests/fixtures/test.ass".to_string()).unwrap();
         ssafile
             .to_file("./tests/fixtures/res4.ass")
             .expect("Couldn't write");
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn test_srt_from_file_to_ass_file() {
         use rsubs_lib::srt;
-        let ssafile = srt::parse("./tests/fixtures/test.srt".to_string()).unwrap();
+        let ssafile = srt::parse_from_file("./tests/fixtures/test.srt".to_string()).unwrap();
         ssafile
             .to_ass()
             .to_file("./tests/fixtures/res3.ass")
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn test_srt_from_file_to_vtt_file() {
         use rsubs_lib::srt;
-        let ssafile = srt::parse("./tests/fixtures/test.srt".to_string()).unwrap();
+        let ssafile = srt::parse_from_file("./tests/fixtures/test.srt".to_string()).unwrap();
         ssafile
             .to_vtt()
             .to_file("./tests/fixtures/res2.vtt")
@@ -78,7 +78,7 @@ mod tests {
             .expect("WrongFile")
             .read_to_string(file_value)
             .expect("Couldn't write");
-        let ssafile = ssa::parse(file_value.to_string()).unwrap();
+        let ssafile = ssa::parse(file_value.to_string());
         ssafile
             .to_srt()
             .to_file("./tests/fixtures/res7.srt")
@@ -87,13 +87,13 @@ mod tests {
     #[test]
     fn test_srt_from_file_to_srt_file() {
         use rsubs_lib::srt;
-        let srtfile = srt::parse("./tests/fixtures/test.srt".to_string()).unwrap();
+        let srtfile = srt::parse_from_file("./tests/fixtures/test.srt".to_string()).unwrap();
         srtfile.to_file("./tests/fixtures/res8.srt").unwrap();
     }
     #[test]
     fn test_srt_from_file_to_srt_file2() {
         use rsubs_lib::srt;
-        srt::parse("./tests/fixtures/test.srt".to_string())
+        srt::parse_from_file("./tests/fixtures/test.srt".to_string())
             .unwrap()
             .to_vtt()
             .to_file("./tests/fixtures/res14.srt")
@@ -158,7 +158,7 @@ You know I’m so excited my glasses are falling off here.
         "
         .to_string();
         let mut srt = rsubs_lib::srt::SRTFile::from_str(&fi).unwrap();
-        let srt2 = rsubs_lib::srt::parse(fi).unwrap();
+        let srt2 = rsubs_lib::srt::parse(fi);
         for line in srt.lines.iter_mut() {
             line.line_end += 1000;
             line.line_start += 1000;
@@ -311,7 +311,7 @@ Dialogue: 0,0:00:02.20,0:00:04.20,Default,,0000,0000,0000,,{\c1}Lorem Ipsum2{\c0
         let _sub10: VTTFile = Subtitle::from_str(fi).unwrap().into();
         let _sub11 = Subtitle::from_str(fi2).unwrap().to_string();
         let _sub11 = Subtitle::from_str(fi3).unwrap().to_string();
-        let _sub12 = rsubs_lib::ssa::parse(fi3.replace("\r\n", "\n")).unwrap();
+        let _sub12 = rsubs_lib::ssa::parse(fi3.replace("\r\n", "\n"));
         assert!(sub2.to_string().contains("We are in New York City"));
         assert!(sub3.to_string().contains("We are in New York City"));
         assert!(sub4.to_string().contains("We are in New York City"));
@@ -432,54 +432,16 @@ font-family: "Arial", sans-serif;
     }
     #[test]
     fn test_time_2() {
-        use rsubs_lib::util::time;
         let timestr = vec!["00:00:20.000", "00:01:20.011", "0:00:05,100", "00:20,40"];
         for (ctr, i) in timestr.iter().enumerate() {
             match ctr {
-                0 => assert_eq!(
-                    Time {
-                        h: 0,
-                        m: 0,
-                        s: 20,
-                        ms: 0,
-                        frames: 0,
-                        fps: 0.0,
-                    },
-                    Time::from_str(i).unwrap()
-                ),
+                0 => assert_eq!(Time::from_ms(20 * 1000), Time::from_str(i).unwrap()),
                 1 => assert_eq!(
-                    Time {
-                        h: 0,
-                        m: 1,
-                        s: 20,
-                        ms: 11,
-                        frames: 0,
-                        fps: 0.0,
-                    },
+                    Time::from_ms(1 * 60 * 1000 + 20 * 1000 + 11),
                     Time::from_str(i).unwrap()
                 ),
-                2 => assert_eq!(
-                    Time {
-                        h: 0,
-                        m: 0,
-                        s: 5,
-                        ms: 100,
-                        frames: 0,
-                        fps: 0.0,
-                    },
-                    Time::from_str(i).unwrap()
-                ),
-                3 => assert_eq!(
-                    Time {
-                        h: 0,
-                        m: 0,
-                        s: 20,
-                        ms: 400,
-                        frames: 0,
-                        fps: 0.0,
-                    },
-                    Time::from_str(i).unwrap()
-                ),
+                2 => assert_eq!(Time::from_ms(5 * 1000 + 100), Time::from_str(i).unwrap()),
+                3 => assert_eq!(Time::from_ms(20 * 1000 + 400), Time::from_str(i).unwrap()),
                 _ => todo!(),
             }
         }
@@ -500,20 +462,15 @@ font-family: "Arial", sans-serif;
         assert_eq!(tr.total_ms(), 0_u32);
         tr += 22000;
         let a: &mut Time = &mut tr;
-        let b = a + 100;
+        let b: &mut Time = a + 100;
         let mut d: &mut Time = &mut Time::default();
         println!("{b}");
         assert_eq!(b.clone().to_srt_string(), "00:00:22,100".to_string());
-        assert_eq!(&mut b.clone() - 100000, d);
-        assert_eq!(b - 100000_u32, d);
         d.set_fps(27.9);
-        assert_eq!(d.fps, 27.9);
-        assert_eq!(d.frames, 0);
+        assert_eq!(d.fps(), 27.9);
+        assert_eq!(d.frames(), 0);
         d = d + 10000;
-        d.derive_frames();
-        assert_eq!(d.frames, 279);
-        d.update_from_fps_frames().unwrap();
-        assert_eq!(time::frames_to_ms(23, 0.0), 0);
+        assert_eq!(d.frames(), 279);
     }
 
     #[test]
@@ -521,14 +478,14 @@ font-family: "Arial", sans-serif;
         use rsubs_lib::srt;
         use std::fs::File;
         use std::io::Read;
-        srt::parse("./tests/fixtures/test.srt".to_string())
+        srt::parse_from_file("./tests/fixtures/test.srt".to_string())
             .unwrap()
             .to_vtt()
             .to_ass()
             .to_srt()
             .to_file("./tests/fixtures/res15.srt")
             .unwrap();
-        let _file_value = srt::parse("./tests/fixtures/test.srt".to_string()).unwrap();
+        let _file_value = srt::parse_from_file("./tests/fixtures/test.srt".to_string()).unwrap();
         let file_value2: &mut String = &mut "".to_string();
         File::open("./tests/fixtures/res15.srt")
             .expect("WrongFile")
@@ -546,7 +503,7 @@ font-family: "Arial", sans-serif;
             .expect("WrongFile")
             .read_to_string(file_value)
             .expect("Couldn't write");
-        let srtfile = srt::parse(file_value.to_string()).unwrap();
+        let srtfile = srt::parse(file_value.to_string());
         srtfile.to_file("./tests/fixtures/res9.srt").unwrap();
     }
     #[test]
@@ -559,7 +516,7 @@ font-family: "Arial", sans-serif;
             .expect("WrongFile")
             .read_to_string(file_valuex)
             .expect("Couldn't write");
-        let srtfile1 = srt::parse(file_valuex.to_string()).unwrap();
+        let srtfile1 = srt::parse(file_valuex.to_string());
         srtfile1.to_file("./tests/fixtures/res13.srt").unwrap();
         let file_value: &mut String = &mut "".to_string();
         File::open("./tests/fixtures/res13.srt")
@@ -571,7 +528,7 @@ font-family: "Arial", sans-serif;
             .expect("WrongFile")
             .read_to_string(file_value2)
             .expect("Couldn't write");
-        let srtfile = srt::parse(file_value.to_string()).unwrap();
+        let srtfile = srt::parse(file_value.to_string());
         assert_eq!(file_value.to_string(), format!("{srtfile}"));
     }
     #[test]
@@ -585,7 +542,7 @@ font-family: "Arial", sans-serif;
             .expect("WrongFile")
             .read_to_string(file_value)
             .expect("Couldn't write");
-        let _vttfile: VTTFile = vtt::parse(file_value.to_owned()).unwrap();
+        let _vttfile: VTTFile = vtt::parse(file_value.to_owned());
     }
     #[test]
     fn test_parse_vtt_write_to_vtt() {
@@ -598,7 +555,6 @@ font-family: "Arial", sans-serif;
             .read_to_string(file_value)
             .expect("Couldn't write");
         vtt::parse(file_value.to_owned())
-            .unwrap()
             .to_file("./tests/fixtures/res10.vtt")
             .expect("Ok");
     }
@@ -613,7 +569,6 @@ font-family: "Arial", sans-serif;
             .read_to_string(file_value)
             .expect("Couldn't write");
         vtt::parse(file_value.to_owned())
-            .unwrap()
             .to_ass()
             .to_file("./tests/fixtures/res11.ass")
             .expect("Ok");
@@ -629,7 +584,6 @@ font-family: "Arial", sans-serif;
             .read_to_string(file_value)
             .expect("Couldn't write");
         vtt::parse(file_value.to_owned())
-            .unwrap()
             .to_srt()
             .to_file("./tests/fixtures/res12.srt")
             .expect("Ok");
@@ -637,7 +591,7 @@ font-family: "Arial", sans-serif;
     #[test]
     fn test_parse_vtt_from_file_to_srt() {
         use rsubs_lib::vtt;
-        vtt::parse("./tests/fixtures/test.vtt".to_owned())
+        vtt::parse_from_file("./tests/fixtures/test.vtt".to_owned())
             .unwrap()
             .to_srt()
             .to_file("./tests/fixtures/res16.srt")
@@ -647,7 +601,7 @@ font-family: "Arial", sans-serif;
     #[should_panic]
     fn test_parse_vtt_from_file_to_srt_panic() {
         use rsubs_lib::vtt;
-        vtt::parse("./tests/fixtures/test.srt".to_owned())
+        vtt::parse_from_file("./tests/fixtures/test.srt".to_owned())
             .unwrap()
             .to_srt()
             .to_file("./tests/fixtures/res12.srt")
@@ -657,7 +611,7 @@ font-family: "Arial", sans-serif;
     #[should_panic]
     fn test_parse_vtt_from_empty_to_srt_panic() {
         use rsubs_lib::vtt;
-        vtt::parse("".to_owned())
+        vtt::parse_from_file("".to_owned())
             .unwrap()
             .to_srt()
             .to_file("./tests/fixtures/res_panic1.srt")


### PR DESCRIPTION
This PR changes some types and functions:
- `srt::parse`, `ssa::parse` and `vtt::parse` do not take file paths as input anymore. For this I've created `srt::parse_from_file`, `ssa::parse_from_file` and `vtt::parse_from_file`. When taking arbitrary user input, or untrusted input in general, and this input is malformed in a way that it resembles a filepath it could lead to unwanted file reads and/or crashes, thus the separation
- Changed `SRTFile::to_file`, `SSAFile::to_file` and `VTTFile::to_file` to take a `Path` reference instead of a `&str` as parameter
- Made all fields in `Time` private and added `Time::fps`, `Time::frames` functions instead
- Renamed `Time::update_from_ms` to `Time::set_ms` and changed the "parsing" to number calculations only
- Added `Time::to_vtt_string`
- Changed parameter for `Time::to_ass_string` and `to_srt_string` to take `self` as reference
- Removed `Time::update_from_fps_frames`, `Time::derive_frames` (this is now called directly when using `Time::frames`), `Time::add_ms` and `Time::sub_ms`
- Removed `time::frames_to_ms`, `time::ms_to_frames` and `time::ms_to_timestring`
- `Add` and `Sub` traits for `Time` got implemented for every integer type and `&mut` integer type reference. When subtracting a value greater than the internal stored time, an overflow error will occur
- `AddAssign` and `SubAssign` traits for `Time` got implemented for every integer type. When subtracting a value greater than the internal stored time, an overflow error will occur