### PR TITLE
Fix `SSAFile` output style reversed boolean

### DIFF
--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -338,23 +338,23 @@ impl Display for SSAFile {
                 + &i.backgroundcolor.to_string()
                 + ","
                 + &i.bold
-                    .then(|| "0".to_string())
-                    .or_else(|| Some("-1".to_string()))
+                    .then(|| "-1".to_string())
+                    .or_else(|| Some("0".to_string()))
                     .expect("Proper")
                 + ","
                 + &i.italic
-                    .then(|| "0".to_string())
-                    .or_else(|| Some("-1".to_string()))
+                    .then(|| "-1".to_string())
+                    .or_else(|| Some("0".to_string()))
                     .expect("Proper")
                 + ","
                 + &i.unerline
-                    .then(|| "0".to_string())
-                    .or_else(|| Some("-1".to_string()))
+                    .then(|| "-1".to_string())
+                    .or_else(|| Some("0".to_string()))
                     .expect("Proper")
                 + ","
                 + &i.strikeout
-                    .then(|| "0".to_string())
-                    .or_else(|| Some("-1".to_string()))
+                    .then(|| "-1".to_string())
+                    .or_else(|| Some("0".to_string()))
                     .expect("Proper")
                 + ","
                 + &(i.scalex as i32).to_string()


### PR DESCRIPTION
When converting `SSAFile` to a string, the boolean values for the `Bold`, `Italic`, `Underline` and `Strikeout` styles are reversed