### PR TITLE
Fix SSA info- & header names

### DIFF
--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -395,7 +395,7 @@ impl Display for SSA {
 
         lines.push("".to_string());
         lines.push("[V4+ Styles]".to_string());
-        lines.push("Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding".to_string());
+        lines.push("Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding".to_string());
         for style in &self.styles {
             let line = [
                 style.name.to_string(),
@@ -509,7 +509,7 @@ mod parse {
                 }
                 "Script Updated By" => info.script_update_by = Some(value.to_string()),
                 "Update Details" => info.update_details = Some(value.to_string()),
-                "Script Type" => info.script_type = Some(value.to_string()),
+                "ScriptType" => info.script_type = Some(value.to_string()),
                 "Collisions" => info.collisions = Some(value.to_string()),
                 "PlayResY" => {
                     info.play_res_y = value.parse::<u32>().map(Some).map_err(|e| Error {

--- a/tests/srt.rs
+++ b/tests/srt.rs
@@ -26,7 +26,7 @@ fn convert_simple_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
@@ -84,7 +84,7 @@ fn convert_styling_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
@@ -126,7 +126,7 @@ fn convert_multiline_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]

--- a/tests/vtt.rs
+++ b/tests/vtt.rs
@@ -41,7 +41,7 @@ fn convert_simple_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
@@ -81,7 +81,7 @@ fn convert_styling_inline_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
@@ -140,7 +140,7 @@ fn convert_styling_global_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,12,&HFF0000,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
@@ -177,7 +177,7 @@ fn convert_multiline_to_ssa() {
     let expected = r"[Script Info]
 
 [V4+ Styles]
-Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColor,BackColour,Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
+Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]


### PR DESCRIPTION
The `OutlineColour` and `Strikeout` style header names are incorrect when printing out the `SSA` struct.
Also, the `ScriptType` header has an additional space (`Script Type`). ~~According to the spec at http://www.tcax.org/docs/ass-specs.htm this is correct, but every ssa subtitle I could find writes it together~~ There are two sections, in one it's written together, in the other not.