### PR TITLE
Allow empty ssa color

### DIFF
--- a/examples/change_style_colors.rs
+++ b/examples/change_style_colors.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for style in &mut ssa.styles {
         if style.name == "Default" {
-            style.primary_color = Color::new(255, 0, 0, 255)
+            style.primary_color = Some(Color::new(255, 0, 0, 255))
         }
     }
 

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use crate::util::{Alignment, BLACK, TRANSPARENT, WHITE};
+use crate::util::Alignment;
 use serde::{Deserialize, Serialize};
 
 use crate::error;
@@ -84,16 +84,16 @@ pub struct SSAStyle {
     /// Fontsize.
     pub fontsize: f32,
     /// The color that a subtitle will normally appear in.
-    pub primary_color: Color,
+    pub primary_color: Option<Color>,
     /// This color may be used instead of the Primary colour when a subtitle is automatically
     /// shifted to prevent an onscreen collision, to distinguish the different subtitles.
-    pub secondary_color: Color,
+    pub secondary_color: Option<Color>,
     /// This color may be used instead of the Primary or Secondary colour when a subtitle is
     /// automatically shifted to prevent an onscreen collision, to distinguish the different
     /// subtitles.
-    pub outline_color: Color,
+    pub outline_color: Option<Color>,
     /// The color of the subtitle outline or shadow.
-    pub back_color: Color,
+    pub back_color: Option<Color>,
     /// Defines whether text is bold or not.
     pub bold: bool,
     /// Defines whether text is italic or not.
@@ -145,10 +145,10 @@ impl Default for SSAStyle {
             name: "Default".to_string(),
             fontname: "Trebuchet MS".to_string(),
             fontsize: 25.5,
-            primary_color: WHITE,
-            secondary_color: BLACK,
-            outline_color: TRANSPARENT,
-            back_color: TRANSPARENT,
+            primary_color: None,
+            secondary_color: None,
+            outline_color: None,
+            back_color: None,
             bold: false,
             italic: false,
             underline: false,
@@ -401,10 +401,10 @@ impl Display for SSA {
                 style.name.to_string(),
                 style.fontname.to_string(),
                 style.fontsize.to_string(),
-                style.primary_color.to_ssa_string(),
-                style.secondary_color.to_ssa_string(),
-                style.outline_color.to_ssa_string(),
-                style.back_color.to_ssa_string(),
+                style.primary_color.map(|c| c.to_ssa_string()).unwrap_or_default(),
+                style.secondary_color.map(|c| c.to_ssa_string()).unwrap_or_default(),
+                style.outline_color.map(|c| c.to_ssa_string()).unwrap_or_default(),
+                style.back_color.map(|c| c.to_ssa_string()).unwrap_or_default(),
                 if style.bold { "-1" } else { "0" }.to_string(),
                 if style.italic { "-1" } else { "0" }.to_string(),
                 if style.underline { "-1" } else { "0" }.to_string(),

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -18,7 +18,7 @@ pub struct Color {
     pub a: u8,
 }
 
-pub(crate) const WHITE: Color = Color {
+pub const WHITE: Color = Color {
     r: 255,
     g: 255,
     b: 255,
@@ -32,7 +32,7 @@ pub const BLACK: Color = Color {
     a: 255,
 };
 
-pub(crate) const TRANSPARENT: Color = Color {
+pub const TRANSPARENT: Color = Color {
     r: 0,
     g: 0,
     b: 0,
@@ -44,17 +44,20 @@ impl Color {
         Self { r, g, b, a }
     }
 
-    pub(crate) fn from_ssa(mut color: &str) -> Result<Self, String> {
+    pub(crate) fn from_ssa(mut color: &str) -> Result<Option<Self>, String> {
         if !color.starts_with("&H") || color.len() != 10 {
+            if color.is_empty() {
+                return Ok(None);
+            }
             return Err(format!("invalid color: #{color}"));
         }
         color = &color[2..];
-        Ok(Self {
+        Ok(Some(Self {
             r: u8::from_str_radix(&color[6..8], 16).map_err(|e| e.to_string())?,
             g: u8::from_str_radix(&color[4..6], 16).map_err(|e| e.to_string())?,
             b: u8::from_str_radix(&color[2..4], 16).map_err(|e| e.to_string())?,
             a: u8::from_str_radix(&color[0..2], 16).map_err(|e| e.to_string())?,
-        })
+        }))
     }
 
     pub(crate) fn from_vtt(color: &str) -> Result<Self, String> {

--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -6,7 +6,7 @@
 use super::srt::{SRTLine, SRT};
 use super::ssa::{SSAEvent, SSAInfo, SSAStyle, SSA};
 use crate::error;
-use crate::util::{Alignment, Color, BLACK, TRANSPARENT, WHITE};
+use crate::util::{Alignment, Color};
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -139,10 +139,10 @@ impl VTT {
             name: "Default".to_string(),
             fontname: "Arial".to_string(),
             fontsize: 20.0,
-            primary_color: WHITE,
-            secondary_color: BLACK,
-            outline_color: TRANSPARENT,
-            back_color: TRANSPARENT,
+            primary_color: None,
+            secondary_color: None,
+            outline_color: None,
+            back_color: None,
             alignment: Alignment::BottomCenter,
             ..Default::default()
         };
@@ -154,13 +154,13 @@ impl VTT {
             // text color. skips if the VTT color can't be read
             if let Some(color) = style.entries.get("color") {
                 if let Ok(primary_color) = Color::from_vtt(color) {
-                    default_style.primary_color = primary_color
+                    default_style.primary_color = Some(primary_color)
                 }
             }
             // background color. skips if the VTT color can't be read
             if let Some(background_color) = style.entries.get("background-color") {
                 if let Ok(back_color) = Color::from_vtt(background_color) {
-                    default_style.back_color = back_color
+                    default_style.back_color = Some(back_color)
                 }
             }
             // font size. can only be converted to SSA if it is given as pixels, in all other

--- a/tests/srt.rs
+++ b/tests/srt.rs
@@ -27,7 +27,7 @@ fn convert_simple_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
@@ -85,7 +85,7 @@ fn convert_styling_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
@@ -127,7 +127,7 @@ fn convert_multiline_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text

--- a/tests/vtt.rs
+++ b/tests/vtt.rs
@@ -42,7 +42,7 @@ fn convert_simple_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
@@ -82,7 +82,7 @@ fn convert_styling_inline_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
@@ -141,7 +141,7 @@ fn convert_styling_global_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,12,&HFF0000,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,12,&HFF0000,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
@@ -178,7 +178,7 @@ fn convert_multiline_to_ssa() {
 
 [V4+ Styles]
 Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,Bold,Italic,Underline,Strikeout,ScaleX,ScaleY,Spacing,Angle,BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
-Style: Default,Arial,20,&HFFFFFF,&H000000,&H00000000,&H00000000,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
+Style: Default,Arial,20,,,,,0,0,0,0,120,120,0,0,1,1,1,2,0,0,20,0
 
 [Events]
 Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text


### PR DESCRIPTION
Apparently an empty string is a valid ssa color. This reorganizes how colors are handles in general with ssa. I've wrapped all colors in the `SSA` struct in an `Option` and changed the `Default` impl to omit any default color.