### PR TITLE
Avoid panic when attempting to parse a completely empty VTT file

### DIFF
--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -357,7 +357,7 @@ mod parse {
     type Result<T> = std::result::Result<T, Error>;
 
     pub(super) fn parse_start<'a, I: Iterator<Item = &'a str>>(mut block_lines: I) -> Result<()> {
-        let line = block_lines.next().unwrap();
+        let line = block_lines.next().unwrap_or_default();
         if !line.starts_with("WEBVTT") {
             return Err(Error {
                 line: 1,

--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -85,7 +85,9 @@ impl VTT {
             blocks.remove(blocks.len() - 1);
         }
 
-        parse::parse_start(blocks.remove(0).into_iter())
+        let mut blocks = blocks.into_iter();
+
+        parse::parse_start(blocks.next().unwrap_or_default().into_iter())
             .map_err(|e| VTTError::new(e.kind, line_num + e.line))?;
 
         line_num += 1;

--- a/tests/vtt.rs
+++ b/tests/vtt.rs
@@ -444,3 +444,12 @@ fn cue_invalid_end_time_hour() {
     assert_eq!(err.line(), 3);
     assert!(matches!(err.kind(), &VTTErrorKind::Parse(_)))
 }
+
+#[test]
+fn parse_empty_file_as_vtt_no_panic() {
+    // We expect this to error out, that's fine, but panicking is bad.
+    let vtt = "";
+
+    let result = VTT::parse(vtt);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This is expected not to parse successfully, but ideally it would return an Err rather than panicking.