### PR TITLE
Parse byte-order mark (BOM) content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,8 @@ macro_rules! error {
     };
 }
 pub(crate) use error;
+
+fn strip_bom<S: AsRef<str>>(content: &S) -> &str {
+    let content = content.as_ref();
+    content.strip_prefix('\u{FEFF}').unwrap_or(content)
+}

--- a/src/srt.rs
+++ b/src/srt.rs
@@ -15,6 +15,7 @@ use crate::error;
 use time::Time;
 
 use super::ssa::SSA;
+use super::strip_bom;
 use super::vtt::{VTTLine, VTT};
 
 const TIME_FORMAT: &[BorrowedFormatItem] =
@@ -54,7 +55,7 @@ impl SRT {
         let mut line_num = 0;
 
         let mut blocks = vec![vec![]];
-        for line in content.as_ref().lines() {
+        for line in strip_bom(&content).lines() {
             if line.trim().is_empty() {
                 if !blocks.last().unwrap().is_empty() {
                     blocks.push(vec![])

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -17,6 +17,7 @@ use crate::vtt::VTT;
 use time::Time;
 
 use super::srt::{SRTLine, SRT};
+use super::strip_bom;
 
 /// [SSAInfo] contains headers and general information about the script.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
@@ -246,7 +247,7 @@ impl SSA {
         let mut line_num = 0;
 
         let mut blocks = vec![vec![]];
-        for line in content.as_ref().lines() {
+        for line in strip_bom(&content).lines() {
             if line.trim().is_empty() {
                 blocks.push(vec![])
             } else {

--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -5,6 +5,7 @@
 
 use super::srt::{SRTLine, SRT};
 use super::ssa::{SSAEvent, SSAInfo, SSAStyle, SSA};
+use super::strip_bom;
 use crate::error;
 use crate::util::{Alignment, Color};
 use regex::Regex;
@@ -72,7 +73,7 @@ impl VTT {
         let mut lines = vec![];
 
         let mut blocks = vec![vec![]];
-        for line in content.as_ref().lines() {
+        for line in strip_bom(&content).lines() {
             if line.trim().is_empty() {
                 if !blocks.last().unwrap().is_empty() {
                     blocks.push(vec![])

--- a/tests/srt.rs
+++ b/tests/srt.rs
@@ -217,3 +217,10 @@ We are in New York City
     assert_eq!(err.line(), 2);
     assert!(matches!(err.kind(), SRTErrorKind::Parse(_)))
 }
+
+#[test]
+fn parse_bom_content() {
+    let bom = format!("\u{FEFF}{}", SIMPLE);
+    let bom = SRT::parse(bom).unwrap();
+    assert_eq!(bom, SRT::parse(SIMPLE).unwrap());
+}

--- a/tests/ssa.rs
+++ b/tests/ssa.rs
@@ -871,3 +871,10 @@ fn parse_complex_ass() {
 
     assert_eq!(ssa.events.len(), 448);
 }
+
+#[test]
+fn parse_bom_content() {
+    let bom = format!("\u{FEFF}{}", SIMPLE);
+    let bom = SSA::parse(bom).unwrap();
+    assert_eq!(bom, SSA::parse(SIMPLE).unwrap());
+}

--- a/tests/vtt.rs
+++ b/tests/vtt.rs
@@ -444,3 +444,10 @@ fn cue_invalid_end_time_hour() {
     assert_eq!(err.line(), 3);
     assert!(matches!(err.kind(), &VTTErrorKind::Parse(_)))
 }
+
+#[test]
+fn parse_bom_content() {
+    let bom = format!("\u{FEFF}{}", SIMPLE);
+    let bom = VTT::parse(bom).unwrap();
+    assert_eq!(bom, VTT::parse(SIMPLE).unwrap());
+}


### PR DESCRIPTION
Added:
- Parse bom content.

Why it’s needed:
Real subtitle files may contain a BOM marker, which is read by the standard library function std::fs::read_to_string. Parsing the resulting string without handling the BOM currently causes errors.